### PR TITLE
Fix small memory leak in tuxpak tool

### DIFF
--- a/src/tuxpak/tuxpak.cpp
+++ b/src/tuxpak/tuxpak.cpp
@@ -542,6 +542,10 @@ void PopPak::close()
         fclose(_fp);
         _fp = 0;
     }
+    for (auto i: _fileinfos) {
+        delete i;
+    }
+    _fileinfos.clear();
 }
 
 void PopPak::printdir()


### PR DESCRIPTION
There is a small (9Kb) memory leak in the tuxpak command included with tuxcap. I compiled tuxcap with AddressSanitizer and UBSanitizer enabled (-fsanitize=address -fsanitize=undefined) with g++ 11. When the build system tries to run tuxpak to generate resources/main.pak, it fails with [an error from LeakSanitizer](https://github.com/keestux/tuxcap/issues/1). The attached patch fixes the 7kb and 2k leaks. I think the other leaks are false positives, but I'm not sure.

Fixes #1.