### PR TITLE
Upgrade to Python3

### DIFF
--- a/src/pycap/PycapApp.cpp
+++ b/src/pycap/PycapApp.cpp
@@ -152,6 +152,8 @@ void PycapApp::Init(int argc, char*argv[], bool bundled)
         LOG(mLogFacil, 1, Logger::format("AppResourceFolder = '%s'", GetAppResourceFolder().c_str()));
     }
 
+    PyImport_AppendInittab("Pycap", NULL);
+    PyImport_AppendInittab("PycapRes", NULL);
     Py_Initialize();
 
     PyRun_SimpleString("import sys");

--- a/src/pycap/PycapApp.cpp
+++ b/src/pycap/PycapApp.cpp
@@ -266,8 +266,8 @@ void PycapApp::Init(int argc, char*argv[], bool bundled)
         PyObject *inObject;
 
         inObject = PyDict_GetItemString(iniDict, "mCompanyName");
-        if (inObject && PyBytes_Check(inObject)) {
-            mCompanyName = PyBytes_AsString(inObject);
+        if (inObject && PyUnicode_Check(inObject)) {
+            mCompanyName = PyUnicode_AsUTF8(inObject);
         } else {
             PyErr_SetString(PyExc_Exception, "appIni doesn't specify mCompanyName correctly");
             PyErr_Print();
@@ -275,8 +275,8 @@ void PycapApp::Init(int argc, char*argv[], bool bundled)
         }
 
         inObject = PyDict_GetItemString(iniDict, "mFullCompanyName");
-        if (inObject && PyBytes_Check(inObject)) {
-            mFullCompanyName = PyBytes_AsString(inObject);
+        if (inObject && PyUnicode_Check(inObject)) {
+            mFullCompanyName = PyUnicode_AsUTF8(inObject);
         } else {
             PyErr_SetString(PyExc_Exception, "appIni doesn't specify mFullCompanyName correctly");
             PyErr_Print();
@@ -284,8 +284,8 @@ void PycapApp::Init(int argc, char*argv[], bool bundled)
         }
 
         inObject = PyDict_GetItemString(iniDict, "mProdName");
-        if (inObject && PyBytes_Check(inObject)) {
-            mProdName = PyBytes_AsString(inObject);
+        if (inObject && PyUnicode_Check(inObject)) {
+            mProdName = PyUnicode_AsUTF8(inObject);
         } else {
             PyErr_SetString(PyExc_Exception, "appIni doesn't specify mProdName correctly");
             PyErr_Print();
@@ -293,8 +293,8 @@ void PycapApp::Init(int argc, char*argv[], bool bundled)
         }
 
         inObject = PyDict_GetItemString(iniDict, "mProductVersion");
-        if (inObject && PyBytes_Check(inObject)) {
-            mProductVersion = PyBytes_AsString(inObject);
+        if (inObject && PyUnicode_Check(inObject)) {
+            mProductVersion = PyUnicode_AsUTF8(inObject);
         } else {
             PyErr_SetString(PyExc_Exception, "appIni doesn't specify mProductVersion correctly");
             PyErr_Print();
@@ -302,8 +302,8 @@ void PycapApp::Init(int argc, char*argv[], bool bundled)
         }
 
         inObject = PyDict_GetItemString(iniDict, "mTitle");
-        if (inObject && PyBytes_Check(inObject)) {
-            mTitle = PyBytes_AsString(inObject);
+        if (inObject && PyUnicode_Check(inObject)) {
+            mTitle = PyUnicode_AsUTF8(inObject);
         } else {
             PyErr_SetString(PyExc_Exception, "appIni doesn't specify mTitle correctly");
             PyErr_Print();
@@ -311,8 +311,8 @@ void PycapApp::Init(int argc, char*argv[], bool bundled)
         }
 
         inObject = PyDict_GetItemString(iniDict, "mRegKey");
-        if (inObject && PyBytes_Check(inObject)) {
-            mRegKey = PyBytes_AsString(inObject);
+        if (inObject && PyUnicode_Check(inObject)) {
+            mRegKey = PyUnicode_AsUTF8(inObject);
         } else {
             PyErr_SetString(PyExc_Exception, "appIni doesn't specify mRegKey correctly");
             PyErr_Print();
@@ -352,8 +352,8 @@ void PycapApp::Init(int argc, char*argv[], bool bundled)
         }
 
         inObject = PyDict_GetItemString(iniDict, "mWindowIconBMP");
-        if (inObject && PyBytes_Check(inObject)) {
-            mWindowIconBMP = PyBytes_AsString(inObject);
+        if (inObject && PyUnicode_Check(inObject)) {
+            mWindowIconBMP = PyUnicode_AsUTF8(inObject);
         }
     } else {
         PyErr_SetString(PyExc_Exception, "appIni object is missing or not a dict");

--- a/src/pycap/PycapApp.cpp
+++ b/src/pycap/PycapApp.cpp
@@ -218,26 +218,34 @@ void PycapApp::Init(int argc, char*argv[], bool bundled)
         {NULL, NULL, 0, NULL}
     };
 
-    Py_InitModule("Pycap", resMethods);
+    PyModuleDef pycap = {
+        PyModuleDef_HEAD_INIT,
+        "Pycap",
+        "",
+        -1,
+        resMethods
+    };
+
+    PyModule_Create(&pycap);
     // general error location warning
     if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_StandardError, "Some kind of python error occurred in PycapApp(), while importing Pycap module.");
+        PyErr_SetString(PyExc_Exception, "Some kind of python error occurred in PycapApp(), while importing Pycap module.");
         PyErr_Print();
         return;
     }
 
     // Open game module
     PyObject *pName;
-    pName = PyString_FromString("game");
+    pName = PyUnicode_FromString("game");
     if (pName == NULL) {
-        PyErr_SetString(PyExc_StandardError, "Failed to create PyString game.py.");
+        PyErr_SetString(PyExc_Exception, "Failed to create PyString game.py.");
         PyErr_Print();
         return;
     }
 
     pModule = PyImport_Import(pName);
     if (pModule == NULL) {
-        PyErr_SetString(PyExc_StandardError, "Failed to import game.py.");
+        PyErr_SetString(PyExc_Exception, "Failed to import game.py.");
         PyErr_Print();
         return; // we're screwed.
     }
@@ -256,97 +264,97 @@ void PycapApp::Init(int argc, char*argv[], bool bundled)
         PyObject *inObject;
 
         inObject = PyDict_GetItemString(iniDict, "mCompanyName");
-        if (inObject && PyString_Check(inObject)) {
-            mCompanyName = PyString_AsString(inObject);
+        if (inObject && PyBytes_Check(inObject)) {
+            mCompanyName = PyBytes_AsString(inObject);
         } else {
-            PyErr_SetString(PyExc_StandardError, "appIni doesn't specify mCompanyName correctly");
+            PyErr_SetString(PyExc_Exception, "appIni doesn't specify mCompanyName correctly");
             PyErr_Print();
             return;
         }
 
         inObject = PyDict_GetItemString(iniDict, "mFullCompanyName");
-        if (inObject && PyString_Check(inObject)) {
-            mFullCompanyName = PyString_AsString(inObject);
+        if (inObject && PyBytes_Check(inObject)) {
+            mFullCompanyName = PyBytes_AsString(inObject);
         } else {
-            PyErr_SetString(PyExc_StandardError, "appIni doesn't specify mFullCompanyName correctly");
+            PyErr_SetString(PyExc_Exception, "appIni doesn't specify mFullCompanyName correctly");
             PyErr_Print();
             return;
         }
 
         inObject = PyDict_GetItemString(iniDict, "mProdName");
-        if (inObject && PyString_Check(inObject)) {
-            mProdName = PyString_AsString(inObject);
+        if (inObject && PyBytes_Check(inObject)) {
+            mProdName = PyBytes_AsString(inObject);
         } else {
-            PyErr_SetString(PyExc_StandardError, "appIni doesn't specify mProdName correctly");
+            PyErr_SetString(PyExc_Exception, "appIni doesn't specify mProdName correctly");
             PyErr_Print();
             return;
         }
 
         inObject = PyDict_GetItemString(iniDict, "mProductVersion");
-        if (inObject && PyString_Check(inObject)) {
-            mProductVersion = PyString_AsString(inObject);
+        if (inObject && PyBytes_Check(inObject)) {
+            mProductVersion = PyBytes_AsString(inObject);
         } else {
-            PyErr_SetString(PyExc_StandardError, "appIni doesn't specify mProductVersion correctly");
+            PyErr_SetString(PyExc_Exception, "appIni doesn't specify mProductVersion correctly");
             PyErr_Print();
             return;
         }
 
         inObject = PyDict_GetItemString(iniDict, "mTitle");
-        if (inObject && PyString_Check(inObject)) {
-            mTitle = PyString_AsString(inObject);
+        if (inObject && PyBytes_Check(inObject)) {
+            mTitle = PyBytes_AsString(inObject);
         } else {
-            PyErr_SetString(PyExc_StandardError, "appIni doesn't specify mTitle correctly");
+            PyErr_SetString(PyExc_Exception, "appIni doesn't specify mTitle correctly");
             PyErr_Print();
             return;
         }
 
         inObject = PyDict_GetItemString(iniDict, "mRegKey");
-        if (inObject && PyString_Check(inObject)) {
-            mRegKey = PyString_AsString(inObject);
+        if (inObject && PyBytes_Check(inObject)) {
+            mRegKey = PyBytes_AsString(inObject);
         } else {
-            PyErr_SetString(PyExc_StandardError, "appIni doesn't specify mRegKey correctly");
+            PyErr_SetString(PyExc_Exception, "appIni doesn't specify mRegKey correctly");
             PyErr_Print();
             return;
         }
 
         inObject = PyDict_GetItemString(iniDict, "mWidth");
-        if (inObject && PyInt_Check(inObject)) {
-            mWidth = PyInt_AsLong(inObject);
+        if (inObject && PyLong_Check(inObject)) {
+            mWidth = PyLong_AsLong(inObject);
         } else {
-            PyErr_SetString(PyExc_StandardError, "appIni doesn't specify mWidth correctly");
+            PyErr_SetString(PyExc_Exception, "appIni doesn't specify mWidth correctly");
             PyErr_Print();
             return;
         }
 
         inObject = PyDict_GetItemString(iniDict, "mHeight");
-        if (inObject && PyInt_Check(inObject)) {
-            mHeight = PyInt_AsLong(inObject);
+        if (inObject && PyLong_Check(inObject)) {
+            mHeight = PyLong_AsLong(inObject);
         } else {
-            PyErr_SetString(PyExc_StandardError, "appIni doesn't specify mHeight correctly");
+            PyErr_SetString(PyExc_Exception, "appIni doesn't specify mHeight correctly");
             PyErr_Print();
             return;
         }
 
         inObject = PyDict_GetItemString(iniDict, "mAutoEnable3D");
-        if (inObject && PyInt_Check(inObject)) {
-            mAutoEnable3D = PyInt_AsLong(inObject) == 1;
+        if (inObject && PyLong_Check(inObject)) {
+            mAutoEnable3D = PyLong_AsLong(inObject) == 1;
         } else {
-            PyErr_SetString(PyExc_StandardError, "appIni doesn't specify mAutoEnable3D correctly");
+            PyErr_SetString(PyExc_Exception, "appIni doesn't specify mAutoEnable3D correctly");
             PyErr_Print();
             return;
         }
 
         inObject = PyDict_GetItemString(iniDict, "mTest3D");
-        if (inObject && PyInt_Check(inObject)) {
-            mTest3D = PyInt_AsLong(inObject) == 1;
+        if (inObject && PyLong_Check(inObject)) {
+            mTest3D = PyLong_AsLong(inObject) == 1;
         }
 
         inObject = PyDict_GetItemString(iniDict, "mWindowIconBMP");
-        if (inObject && PyString_Check(inObject)) {
-            mWindowIconBMP = PyString_AsString(inObject);
+        if (inObject && PyBytes_Check(inObject)) {
+            mWindowIconBMP = PyBytes_AsString(inObject);
         }
     } else {
-        PyErr_SetString(PyExc_StandardError, "appIni object is missing or not a dict");
+        PyErr_SetString(PyExc_Exception, "appIni object is missing or not a dict");
         PyErr_Print();
         return;
     }
@@ -396,7 +404,7 @@ void PycapApp::LoadingThreadCompleted()
     if (mResFailed || !PycapApp::sApp->pDict) {
         // Nothing much happens if we return before adding the board... just a black screen
         // Error message widget should be added here
-        PyErr_SetString(PyExc_StandardError, "The game did not load properly. Sorry, but it's not going to work.");
+        PyErr_SetString(PyExc_Exception, "The game did not load properly. Sorry, but it's not going to work.");
         PyErr_Print();
         mShutdown = true;
         return;
@@ -499,7 +507,7 @@ PyObject* PycapApp::pSetColour(PyObject* self, PyObject* args)
     // parse the arguments
     int r, g, b, a;
     if (!PyArg_ParseTuple(args, "iiii", &r, &g, &b, &a)) {
-        PyErr_SetString(PyExc_StandardError, "setColour: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "setColour: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -509,7 +517,7 @@ PyObject* PycapApp::pSetColour(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "SetColour() failed: Not currently drawing!");
+        PyErr_SetString(PyExc_Exception, "SetColour() failed: Not currently drawing!");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -532,7 +540,7 @@ PyObject* PycapApp::pSetFont(PyObject* self, PyObject* args)
     // parse the arguments
     int i;
     if (!PyArg_ParseTuple(args, "i", &i)) {
-        PyErr_SetString(PyExc_StandardError, "setFont: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "setFont: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -542,7 +550,7 @@ PyObject* PycapApp::pSetFont(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "setFont() failed: Not currently drawing!");
+        PyErr_SetString(PyExc_Exception, "setFont() failed: Not currently drawing!");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -552,7 +560,7 @@ PyObject* PycapApp::pSetFont(PyObject* self, PyObject* args)
     Font* font = sApp->mResources->getFont(i);
     if (!font) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "setFont: Failed to reference font.");
+        PyErr_SetString(PyExc_Exception, "setFont: Failed to reference font.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -577,7 +585,7 @@ PyObject* PycapApp::pSetColourize(PyObject* self, PyObject* args)
     // parse the arguments
     int colourize;
     if (!PyArg_ParseTuple(args, "i", &colourize)) {
-        PyErr_SetString(PyExc_StandardError, "setColourize: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "setColourize: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -587,7 +595,7 @@ PyObject* PycapApp::pSetColourize(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "setColourize: Not currently drawing");
+        PyErr_SetString(PyExc_Exception, "setColourize: Not currently drawing");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -610,7 +618,7 @@ PyObject* PycapApp::pFillRect(PyObject* self, PyObject* args)
     // parse the arguments
     int x, y, w, h;
     if (!PyArg_ParseTuple(args, "iiii", &x, &y, &w, &h)) {
-        PyErr_SetString(PyExc_StandardError, "fillRect: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "fillRect: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -620,7 +628,7 @@ PyObject* PycapApp::pFillRect(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "fillRect: Not currently drawing");
+        PyErr_SetString(PyExc_Exception, "fillRect: Not currently drawing");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -643,7 +651,7 @@ PyObject* PycapApp::pDrawLine(PyObject* self, PyObject* args)
     // parse the arguments
     int sx, sy, ex, ey;
     if (!PyArg_ParseTuple(args, "iiii", &sx, &sy, &ex, &ey)) {
-        PyErr_SetString(PyExc_StandardError, "drawLine: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "drawLine: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -653,7 +661,7 @@ PyObject* PycapApp::pDrawLine(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "drawLine: Not currently drawing");
+        PyErr_SetString(PyExc_Exception, "drawLine: Not currently drawing");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -676,7 +684,7 @@ PyObject* PycapApp::pDrawImage(PyObject* self, PyObject* args)
     // parse the arguments
     int i, x, y;
     if (!PyArg_ParseTuple(args, "iii", &i, &x, &y)) {
-        PyErr_SetString(PyExc_StandardError, "drawImage: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "drawImage: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -686,7 +694,7 @@ PyObject* PycapApp::pDrawImage(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "drawImage: Not currently drawing");
+        PyErr_SetString(PyExc_Exception, "drawImage: Not currently drawing");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -696,7 +704,7 @@ PyObject* PycapApp::pDrawImage(PyObject* self, PyObject* args)
     Image* image = sApp->mResources->getImage(i);
     if (!image) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "drawImage: Failed to reference image.");
+        PyErr_SetString(PyExc_Exception, "drawImage: Failed to reference image.");
         PyErr_Print();
         // exit, returning None/NULL
         Py_INCREF(Py_None);
@@ -721,7 +729,7 @@ PyObject* PycapApp::pDrawImageF(PyObject* self, PyObject* args)
     int i;
     float x, y;
     if (!PyArg_ParseTuple(args, "iff", &i, &x, &y)) {
-        PyErr_SetString(PyExc_StandardError, "drawImageF: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "drawImageF: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -731,7 +739,7 @@ PyObject* PycapApp::pDrawImageF(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "drawImageF: Not currently drawing");
+        PyErr_SetString(PyExc_Exception, "drawImageF: Not currently drawing");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -741,7 +749,7 @@ PyObject* PycapApp::pDrawImageF(PyObject* self, PyObject* args)
     Image* image = sApp->mResources->getImage(i);
     if (!image) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "drawImageF: Failed to reference image.");
+        PyErr_SetString(PyExc_Exception, "drawImageF: Failed to reference image.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -767,7 +775,7 @@ PyObject* PycapApp::pDrawImageRot(PyObject* self, PyObject* args)
     int i;
     float x, y, r;
     if (!PyArg_ParseTuple(args, "ifff", &i, &x, &y, &r)) {
-        PyErr_SetString(PyExc_StandardError, "drawImageRot: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "drawImageRot: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -777,7 +785,7 @@ PyObject* PycapApp::pDrawImageRot(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "drawImageRot: Not currently drawing");
+        PyErr_SetString(PyExc_Exception, "drawImageRot: Not currently drawing");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -787,7 +795,7 @@ PyObject* PycapApp::pDrawImageRot(PyObject* self, PyObject* args)
     Image* image = sApp->mResources->getImage(i);
     if (!image) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "drawImageRot: Failed to reference image.");
+        PyErr_SetString(PyExc_Exception, "drawImageRot: Failed to reference image.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -813,7 +821,7 @@ PyObject* PycapApp::pDrawImageRotF(PyObject* self, PyObject* args)
     int i;
     float x, y, r;
     if (!PyArg_ParseTuple(args, "ifff", &i, &x, &y, &r)) {
-        PyErr_SetString(PyExc_StandardError, "drawImageRotF: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "drawImageRotF: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -823,7 +831,7 @@ PyObject* PycapApp::pDrawImageRotF(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "drawImageRotF: Not currently drawing");
+        PyErr_SetString(PyExc_Exception, "drawImageRotF: Not currently drawing");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -833,7 +841,7 @@ PyObject* PycapApp::pDrawImageRotF(PyObject* self, PyObject* args)
     Image* image = sApp->mResources->getImage(i);
     if (!image) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "drawImageRotF: Failed to reference image.");
+        PyErr_SetString(PyExc_Exception, "drawImageRotF: Failed to reference image.");
         PyErr_Print();
         // exit, returning None/NULL
         Py_INCREF(Py_None);
@@ -858,7 +866,7 @@ PyObject* PycapApp::pDrawImageScaled(PyObject* self, PyObject* args)
     int i;
     float x, y, w, h;
     if (!PyArg_ParseTuple(args, "iffff", &i, &x, &y, &w, &h)) {
-        PyErr_SetString(PyExc_StandardError, "drawImageScaled: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "drawImageScaled: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -868,7 +876,7 @@ PyObject* PycapApp::pDrawImageScaled(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "drawImageScaled: Not currently drawing");
+        PyErr_SetString(PyExc_Exception, "drawImageScaled: Not currently drawing");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -878,7 +886,7 @@ PyObject* PycapApp::pDrawImageScaled(PyObject* self, PyObject* args)
     Image* image = sApp->mResources->getImage(i);
     if (!image) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "drawImageScaled:Failed to reference image.");
+        PyErr_SetString(PyExc_Exception, "drawImageScaled:Failed to reference image.");
         PyErr_Print();
         // exit, returning None/NULL
         Py_INCREF(Py_None);
@@ -913,7 +921,7 @@ PyObject* PycapApp::pDrawString(PyObject* self, PyObject* args)
     char* string;
     float x, y;
     if (!PyArg_ParseTuple(args, "sff", &string, &x, &y)) {
-        PyErr_SetString(PyExc_StandardError, "drawString: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "drawString: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -923,7 +931,7 @@ PyObject* PycapApp::pDrawString(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "drawString: Not currently drawing");
+        PyErr_SetString(PyExc_Exception, "drawString: Not currently drawing");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -946,7 +954,7 @@ PyObject* PycapApp::pShowMouse(PyObject* self, PyObject* args)
     // parse the arguments
     int show;
     if (!PyArg_ParseTuple(args, "i", &show)) {
-        PyErr_SetString(PyExc_StandardError, "showMouse: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "showMouse: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -974,7 +982,7 @@ PyObject* PycapApp::pDrawmodeNormal(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "drawmodeNormal: Not currently drawing");
+        PyErr_SetString(PyExc_Exception, "drawmodeNormal: Not currently drawing");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -998,7 +1006,7 @@ PyObject* PycapApp::pDrawmodeAdd(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "drawmodeAdd: Not currently drawing");
+        PyErr_SetString(PyExc_Exception, "drawmodeAdd: Not currently drawing");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1026,7 +1034,7 @@ PyObject* PycapApp::pPlaySound(PyObject* self, PyObject* args)
     float panning = 0.0f;
     float pitchAdjust = 0.0f;
     if (!PyArg_ParseTuple(args, "i|fff", &index, &volume, &panning, &pitchAdjust)) {
-        PyErr_SetString(PyExc_StandardError, "playSound: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "playSound: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1035,7 +1043,7 @@ PyObject* PycapApp::pPlaySound(PyObject* self, PyObject* args)
     // check that the sound exists
     if (!sApp->mResources->soundExists(index)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Failed to reference sound.");
+        PyErr_SetString(PyExc_Exception, "Failed to reference sound.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -1054,7 +1062,7 @@ PyObject* PycapApp::pPlaySound(PyObject* self, PyObject* args)
         sound->Play(false, true); // Play sound. Always auto-release the instance.
     } else {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Failed to reference sound.");
+        PyErr_SetString(PyExc_Exception, "Failed to reference sound.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -1076,7 +1084,7 @@ PyObject* PycapApp::pReadReg(PyObject* self, PyObject* args)
     // parse the arguments
     char* key;
     if (!PyArg_ParseTuple(args, "s", &key)) {
-        PyErr_SetString(PyExc_StandardError, "readReg: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "readReg: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1104,7 +1112,7 @@ PyObject* PycapApp::pWriteReg(PyObject* self, PyObject* args)
     char* key;
     char* string;
     if (!PyArg_ParseTuple(args, "ss", &key, &string)) {
-        PyErr_SetString(PyExc_StandardError, "writeReg: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "writeReg: failed to parse arguments");
         PyErr_Print();
         return Py_BuildValue("i", 0);
     }
@@ -1130,7 +1138,7 @@ PyObject* PycapApp::pPlayTune(PyObject* self, PyObject* args)
     int i;
     int repeatCount = 0; //do not loop
     if (!PyArg_ParseTuple(args, "i|i", &i, &repeatCount)) {
-        PyErr_SetString(PyExc_StandardError, "playTune: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "playTune: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1139,7 +1147,7 @@ PyObject* PycapApp::pPlayTune(PyObject* self, PyObject* args)
     int index = sApp->mResources->getTune(i);
     if (index == -1) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Failed to reference tune.");
+        PyErr_SetString(PyExc_Exception, "Failed to reference tune.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -1163,7 +1171,7 @@ PyObject* PycapApp::pStopTune(PyObject* self, PyObject* args)
     // parse the arguments
     int i = -1;
     if (!PyArg_ParseTuple(args, "|i", &i)) {
-        PyErr_SetString(PyExc_StandardError, "stopTune: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "stopTune: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1172,7 +1180,7 @@ PyObject* PycapApp::pStopTune(PyObject* self, PyObject* args)
     int index = sApp->mResources->getTune(i);
     if (index == -1) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Failed to reference tune.");
+        PyErr_SetString(PyExc_Exception, "Failed to reference tune.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -1197,7 +1205,7 @@ PyObject* PycapApp::pSetVolume(PyObject* self, PyObject* args)
     float vol;
 
     if (!PyArg_ParseTuple(args, "f", &vol)) {
-        PyErr_SetString(PyExc_StandardError, "setVolume: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "setVolume: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1221,7 +1229,7 @@ PyObject* PycapApp::pSetTuneVolume(PyObject* self, PyObject* args)
     float vol;
 
     if (!PyArg_ParseTuple(args, "if", &index, &vol)) {
-        PyErr_SetString(PyExc_StandardError, "setTuneVolume: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "setTuneVolume: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1243,7 +1251,7 @@ PyObject* PycapApp::pSetClipRect(PyObject* self, PyObject* args)
     // parse the arguments
     int x, y, w, h;
     if (!PyArg_ParseTuple(args, "iiii", &x, &y, &w, &h)) {
-        PyErr_SetString(PyExc_StandardError, "setClipRect: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "setClipRect: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1253,7 +1261,7 @@ PyObject* PycapApp::pSetClipRect(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "setClipRect: Not currently drawing");
+        PyErr_SetString(PyExc_Exception, "setClipRect: Not currently drawing");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1276,7 +1284,7 @@ PyObject* PycapApp::pClearClipRect(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "ClearClipRect() failed: Not currently drawing!");
+        PyErr_SetString(PyExc_Exception, "ClearClipRect() failed: Not currently drawing!");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1299,7 +1307,7 @@ PyObject* PycapApp::pSetTranslation(PyObject* self, PyObject* args)
     // parse the arguments
     int x, y;
     if (!PyArg_ParseTuple(args, "ii", &x, &y)) {
-        PyErr_SetString(PyExc_StandardError, "setTranslation: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "setTranslation: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1309,7 +1317,7 @@ PyObject* PycapApp::pSetTranslation(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "setTranslation: Not currently drawing!");
+        PyErr_SetString(PyExc_Exception, "setTranslation: Not currently drawing!");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1332,7 +1340,7 @@ PyObject* PycapApp::pSetFullscreen(PyObject* self, PyObject* args)
     // parse the arguments
     int fullscreen;
     if (!PyArg_ParseTuple(args, "i", &fullscreen)) {
-        PyErr_SetString(PyExc_StandardError, "setFullScreen: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "setFullScreen: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1368,7 +1376,7 @@ PyObject* PycapApp::pAllowAllAccess(PyObject* self, PyObject* args)
     // parse the arguments
     char* fileName;
     if (!PyArg_ParseTuple(args, "s", &fileName)) {
-        PyErr_SetString(PyExc_StandardError, "allowAllAccess: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "allowAllAccess: failed to parse arguments");
         PyErr_Print();
         return Py_BuildValue("i", 0);
     }
@@ -1389,7 +1397,7 @@ PyObject* PycapApp::pGetKeyCode(PyObject* self, PyObject* args)
     // parse the arguments
     char* key;
     if (!PyArg_ParseTuple(args, "s", &key)) {
-        PyErr_SetString(PyExc_StandardError, "getKeyCode: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "getKeyCode: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1423,7 +1431,7 @@ PyObject* PycapApp::pIsKeyDown(PyObject* self, PyObject* args)
     // parse the arguments
     int keycode;
     if (!PyArg_ParseTuple(args, "i", &keycode)) {
-        PyErr_SetString(PyExc_StandardError, "isKeyDown: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "isKeyDown: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1455,7 +1463,7 @@ PyObject* PycapApp::pGetAppDataFolder(PyObject* self, PyObject* args)
     // get the folder string
     std::string string = gSexyAppBase->GetAppDataFolder();
     if (string.empty()) {
-        PyErr_SetString(PyExc_StandardError, "AppDataFolder not set");
+        PyErr_SetString(PyExc_Exception, "AppDataFolder not set");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1488,7 +1496,7 @@ PyObject* PycapApp::pDrawImageRotScaled(PyObject* self, PyObject* args)
     int i;
     float x, y, r, scaleX, scaleY;
     if (!PyArg_ParseTuple(args, "ifffff", &i, &x, &y, &r, &scaleX, &scaleY)) {
-        PyErr_SetString(PyExc_StandardError, "drawImageRotScaled: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "drawImageRotScaled: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1498,7 +1506,7 @@ PyObject* PycapApp::pDrawImageRotScaled(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "drawImageRotScaled: Not currently drawing!");
+        PyErr_SetString(PyExc_Exception, "drawImageRotScaled: Not currently drawing!");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1508,7 +1516,7 @@ PyObject* PycapApp::pDrawImageRotScaled(PyObject* self, PyObject* args)
     Image* image = sApp->mResources->getImage(i);
     if (!image) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Failed to reference image.");
+        PyErr_SetString(PyExc_Exception, "Failed to reference image.");
         PyErr_Print();
         // exit, returning None/NULL
         Py_INCREF(Py_None);
@@ -1541,7 +1549,7 @@ PyObject* PycapApp::pSet3DAccelerated(PyObject* self, PyObject* args)
 {
     int accelerate;
     if (!PyArg_ParseTuple(args, "i", &accelerate)) {
-        PyErr_SetString(PyExc_StandardError, "set3DAccelerated: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "set3DAccelerated: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1565,7 +1573,7 @@ PyObject* PycapApp::pDrawQuad(PyObject* self, PyObject* args)
     // parse the arguments
     int x1, y1, x2, y2, x3, y3, x4, y4;
     if (!PyArg_ParseTuple(args, "iiiiiiii", &x1, &y1, &x2, &y2, &x3, &y3, &x4, &y4)) {
-        PyErr_SetString(PyExc_StandardError, "drawQuad: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "drawQuad: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1575,7 +1583,7 @@ PyObject* PycapApp::pDrawQuad(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "drawQuad failed: Not currently drawing!");
+        PyErr_SetString(PyExc_Exception, "drawQuad failed: Not currently drawing!");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1603,7 +1611,7 @@ PyObject* PycapApp::pDrawTri(PyObject* self, PyObject* args)
     // parse the arguments
     int x1, y1, x2, y2, x3, y3;
     if (!PyArg_ParseTuple(args, "iiiiii", &x1, &y1, &x2, &y2, &x3, &y3)) {
-        PyErr_SetString(PyExc_StandardError, "drawTri: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "drawTri: failed to parse arguments");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1613,7 +1621,7 @@ PyObject* PycapApp::pDrawTri(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "drawTri() failed: Not currently drawing!");
+        PyErr_SetString(PyExc_Exception, "drawTri() failed: Not currently drawing!");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;
@@ -1647,7 +1655,7 @@ PyObject* PycapApp::pDrawQuadTextured(PyObject* self, PyObject* args)
     Graphics* graphics = sApp->mBoard->getGraphics();
     if (!graphics) {
         // fail, 'cos we can only do this while drawing
-        PyErr_SetString(PyExc_StandardError, "drawQuadTextured() failed: Not currently drawing!");
+        PyErr_SetString(PyExc_Exception, "drawQuadTextured() failed: Not currently drawing!");
         PyErr_Print();
         Py_INCREF(Py_None);
         return Py_None;

--- a/src/pycap/PycapBoard.cpp
+++ b/src/pycap/PycapBoard.cpp
@@ -31,7 +31,7 @@ using namespace Sexy;
 PycapBoard::PycapBoard()
 {
     if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_StandardError, "Some kind of python error at start of PycapBoard()");
+        PyErr_SetString(PyExc_Exception, "Some kind of python error at start of PycapBoard()");
         PyErr_Print();
         return;
     }
@@ -65,7 +65,7 @@ PycapBoard::PycapBoard()
         if (PyCallable_Check(pInitFunc)) {
             PyObject_CallObject(pInitFunc, NULL);
 	    if (PyErr_Occurred()) {
-		PyErr_SetString(PyExc_StandardError, "Some kind of python error after PycapBoard() calling init");
+		PyErr_SetString(PyExc_Exception, "Some kind of python error after PycapBoard() calling init");
 		PyErr_Print();
 		return;
 	    }
@@ -76,7 +76,7 @@ PycapBoard::PycapBoard()
 
     // general error location warning
     if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_StandardError, "Some kind of python error occurred in PycapBoard()");
+        PyErr_SetString(PyExc_Exception, "Some kind of python error occurred in PycapBoard()");
         PyErr_Print();
         return;
     }
@@ -99,7 +99,7 @@ PycapBoard::~PycapBoard()
     }
     // general error location warning
     if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_StandardError, "Some kind of python error occurred in ~PycapBoard()");
+        PyErr_SetString(PyExc_Exception, "Some kind of python error occurred in ~PycapBoard()");
         PyErr_Print();
     }
 }
@@ -117,7 +117,7 @@ void PycapBoard::UpdateF(float delta)
     // Checked on entering incase a non-update function has set it
     if (pExitGame) {
         PyObject* pExit = PyObject_CallObject(pExitGame, NULL);
-        if (PyInt_Check(pExit) && PyInt_AsLong(pExit) != 0) {
+        if (PyLong_Check(pExit) && PyLong_AsLong(pExit) != 0) {
             // drop the return value
             Py_DECREF(pExit);
 
@@ -146,7 +146,7 @@ void PycapBoard::UpdateF(float delta)
     // Checked on exiting updatef incase it has set it
     if (pExitGame) {
         PyObject* pExit = PyObject_CallObject(pExitGame, NULL);
-        if (PyInt_Check(pExit) && PyInt_AsLong(pExit) != 0) {
+        if (PyLong_Check(pExit) && PyLong_AsLong(pExit) != 0) {
             // drop the return value
             Py_DECREF(pExit);
 
@@ -162,7 +162,7 @@ void PycapBoard::UpdateF(float delta)
 
     // general error location warning
     if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_StandardError, "Some kind of python error occurred in Update");
+        PyErr_SetString(PyExc_Exception, "Some kind of python error occurred in Update");
         PyErr_Print();
         PycapApp::sApp->mShutdown = true;
     }
@@ -189,7 +189,7 @@ void PycapBoard::Draw(Graphics *g)
 
     // general error location warning
     if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_StandardError, "Some kind of python error occurred in Draw");
+        PyErr_SetString(PyExc_Exception, "Some kind of python error occurred in Draw");
         PyErr_Print();
         PycapApp::sApp->mShutdown = true;
     }
@@ -207,14 +207,14 @@ void PycapBoard::KeyDown(KeyCode key)
 
     // Python keydown hook
     PyObject* pArgs = PyTuple_New(1);
-    PyObject* pKey = PyInt_FromLong(key);
+    PyObject* pKey = PyLong_FromLong(key);
     PyTuple_SetItem(pArgs, 0, pKey);
     PyObject_CallObject(pKeyDownFunc, pArgs);
     Py_DECREF(pArgs);
 
     // general error location warning
     if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_StandardError, "Some kind of python error occurred in KeyDown");
+        PyErr_SetString(PyExc_Exception, "Some kind of python error occurred in KeyDown");
         PyErr_Print();
         PycapApp::sApp->mShutdown = true;
     }
@@ -232,14 +232,14 @@ void PycapBoard::KeyUp(KeyCode key)
 
     // Python keyup hook
     PyObject* pArgs = PyTuple_New(1);
-    PyObject* pKey = PyInt_FromLong(key);
+    PyObject* pKey = PyLong_FromLong(key);
     PyTuple_SetItem(pArgs, 0, pKey);
     PyObject_CallObject(pKeyUpFunc, pArgs);
     Py_DECREF(pArgs);
 
     // general error location warning
     if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_StandardError, "Some kind of python error occurred in KeyUp");
+        PyErr_SetString(PyExc_Exception, "Some kind of python error occurred in KeyUp");
         PyErr_Print();
         PycapApp::sApp->mShutdown = true;
     }
@@ -257,7 +257,7 @@ void PycapBoard::MouseEnter()
 
     // general error location warning
     if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_StandardError, "Some kind of python error occurred in MouseEnter");
+        PyErr_SetString(PyExc_Exception, "Some kind of python error occurred in MouseEnter");
         PyErr_Print();
         PycapApp::sApp->mShutdown = true;
     }
@@ -275,7 +275,7 @@ void PycapBoard::MouseLeave()
 
     // general error location warning
     if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_StandardError, "Some kind of python error occurred in MouseLeave");
+        PyErr_SetString(PyExc_Exception, "Some kind of python error occurred in MouseLeave");
         PyErr_Print();
         PycapApp::sApp->mShutdown = true;
     }
@@ -290,8 +290,8 @@ void PycapBoard::MouseMove(int x, int y)
     // Python mouse move hook
     if (pMouseMoveFunc) {
         PyObject* pArgs = PyTuple_New(2);
-        PyObject* pX = PyInt_FromLong(x);
-        PyObject* pY = PyInt_FromLong(y);
+        PyObject* pX = PyLong_FromLong(x);
+        PyObject* pY = PyLong_FromLong(y);
         PyTuple_SetItem(pArgs, 0, pX);
         PyTuple_SetItem(pArgs, 1, pY);
         PyObject_CallObject(pMouseMoveFunc, pArgs);
@@ -299,7 +299,7 @@ void PycapBoard::MouseMove(int x, int y)
 
         // general error location warning
         if (PyErr_Occurred()) {
-            PyErr_SetString(PyExc_StandardError, "Some kind of python error occurred in MouseMove");
+            PyErr_SetString(PyExc_Exception, "Some kind of python error occurred in MouseMove");
             PyErr_Print();
             PycapApp::sApp->mShutdown = true;
         }
@@ -326,9 +326,9 @@ void PycapBoard::MouseDown(int x, int y, int theBtnNum, int theClickCount)
     // Python mouse down hook
     if (pMouseDownFunc) {
         PyObject* pArgs = PyTuple_New(3);
-        PyObject* pX = PyInt_FromLong(x);
-        PyObject* pY = PyInt_FromLong(y);
-        PyObject* pButton = PyInt_FromLong(theBtnNum);
+        PyObject* pX = PyLong_FromLong(x);
+        PyObject* pY = PyLong_FromLong(y);
+        PyObject* pButton = PyLong_FromLong(theBtnNum);
         PyTuple_SetItem(pArgs, 0, pX);
         PyTuple_SetItem(pArgs, 1, pY);
         PyTuple_SetItem(pArgs, 2, pButton);
@@ -337,7 +337,7 @@ void PycapBoard::MouseDown(int x, int y, int theBtnNum, int theClickCount)
 
         // general error location warning
         if (PyErr_Occurred()) {
-            PyErr_SetString(PyExc_StandardError, "Some kind of python error occurred in MouseDown");
+            PyErr_SetString(PyExc_Exception, "Some kind of python error occurred in MouseDown");
             PyErr_Print();
             PycapApp::sApp->mShutdown = true;
         }
@@ -353,9 +353,9 @@ void PycapBoard::MouseUp(int x, int y, int theBtnNum, int theClickCount)
     // Python mouse up hook
     if (pMouseUpFunc) {
         PyObject* pArgs = PyTuple_New(3);
-        PyObject* pX = PyInt_FromLong(x);
-        PyObject* pY = PyInt_FromLong(y);
-        PyObject* pButton = PyInt_FromLong(theBtnNum);
+        PyObject* pX = PyLong_FromLong(x);
+        PyObject* pY = PyLong_FromLong(y);
+        PyObject* pButton = PyLong_FromLong(theBtnNum);
         PyTuple_SetItem(pArgs, 0, pX);
         PyTuple_SetItem(pArgs, 1, pY);
         PyTuple_SetItem(pArgs, 2, pButton);
@@ -364,7 +364,7 @@ void PycapBoard::MouseUp(int x, int y, int theBtnNum, int theClickCount)
 
         // general error location warning
         if (PyErr_Occurred()) {
-            PyErr_SetString(PyExc_StandardError, "Some kind of python error occurred in MouseUp");
+            PyErr_SetString(PyExc_Exception, "Some kind of python error occurred in MouseUp");
             PyErr_Print();
             PycapApp::sApp->mShutdown = true;
         }
@@ -380,14 +380,14 @@ void PycapBoard::MouseWheel(int delta)
     // Python mouse move hook
     if (pMouseWheelFunc) {
         PyObject* pArgs = PyTuple_New(1);
-        PyObject* pX = PyInt_FromLong(delta);
+        PyObject* pX = PyLong_FromLong(delta);
         PyTuple_SetItem(pArgs, 0, pX);
         PyObject_CallObject(pMouseWheelFunc, pArgs);
         Py_DECREF(pArgs);
 
         // general error location warning
         if (PyErr_Occurred()) {
-            PyErr_SetString(PyExc_StandardError, "Some kind of python error occurred in MouseWheel");
+            PyErr_SetString(PyExc_Exception, "Some kind of python error occurred in MouseWheel");
             PyErr_Print();
             PycapApp::sApp->mShutdown = true;
         }

--- a/src/pycap/PycapResources.cpp
+++ b/src/pycap/PycapResources.cpp
@@ -73,10 +73,17 @@ PycapResources::PycapResources()
         {"mashImage", pMashImage, METH_VARARGS, ""},
         {NULL, NULL, 0, NULL}
     };
-    Py_InitModule("PycapRes", resMethods);
+    PyModuleDef pycapRes = {
+        PyModuleDef_HEAD_INIT,
+		"PycapRes",
+		"",
+		-1,
+		resMethods
+    };
+    PyModule_Create(&pycapRes);
     // general error location warning
     if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_StandardError, "Some kind of python error occurred in PycapResources(), while importing PycapRes.");
+        PyErr_SetString(PyExc_Exception, "Some kind of python error occurred in PycapResources(), while importing PycapRes.");
         PyErr_Print();
         return;
     }
@@ -97,7 +104,7 @@ PycapResources::PycapResources()
     }
     // general error location warning
     if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_StandardError, "Some kind of python error occurred in PycapResources(), while running loadBase.");
+        PyErr_SetString(PyExc_Exception, "Some kind of python error occurred in PycapResources(), while running loadBase.");
         PyErr_Print();
         return;
     }
@@ -181,7 +188,7 @@ Image* PycapResources::loadImage(const std::string& fileName)
     Image* newImage = (DDImage*) PycapApp::sApp->GetImage(fileName);
     if (newImage == NULL) {
         PycapApp::sApp->resLoadFailed();
-        PyErr_SetString(PyExc_StandardError, ("Image " + fileName + " could not be loaded").c_str());
+        PyErr_SetString(PyExc_Exception, ("Image " + fileName + " could not be loaded").c_str());
         PyErr_Print();
         return NULL;
     }
@@ -220,7 +227,7 @@ Font* PycapResources::loadFont(const std::string& fileName)
     if (!newFont->mFontData->mInitialized) {
         delete newFont;
         PycapApp::sApp->resLoadFailed();
-        PyErr_SetString(PyExc_StandardError, ("Font " + fileName + " could not be loaded").c_str());
+        PyErr_SetString(PyExc_Exception, ("Font " + fileName + " could not be loaded").c_str());
         PyErr_Print();
         return NULL;
     }
@@ -254,7 +261,7 @@ Font* PycapResources::sysFont(
     // return new font
     return newFont;
 #else
-    PyErr_SetString(PyExc_StandardError, ("System Font " + faceName + " could not be loaded").c_str());
+    PyErr_SetString(PyExc_Exception, ("System Font " + faceName + " could not be loaded").c_str());
     PyErr_Print();
     return NULL;
 #endif
@@ -287,7 +294,7 @@ bool PycapResources::loadSound(int id, const std::string& fileName)
     if (!PycapApp::sApp->mSoundManager || !PycapApp::sApp->mSoundManager->LoadSound(id, fileName)) {
         // report error
         PycapApp::sApp->resLoadFailed();
-        PyErr_SetString(PyExc_StandardError, ("Sound " + fileName + " could not be loaded").c_str());
+        PyErr_SetString(PyExc_Exception, ("Sound " + fileName + " could not be loaded").c_str());
         PyErr_Print();
 
         return false;
@@ -327,7 +334,7 @@ PyObject* PycapResources::pLoadImage(PyObject* self, PyObject* args)
     char* filename;
     if (!PyArg_ParseTuple(args, "s", &filename)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "loadImage: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "loadImage: failed to parse arguments");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -340,7 +347,7 @@ PyObject* PycapResources::pLoadImage(PyObject* self, PyObject* args)
     Image* newImage = sRes->loadImage(filename);
     if (!newImage) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "loadImage: Failed to load image file");
+        PyErr_SetString(PyExc_Exception, "loadImage: Failed to load image file");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -382,7 +389,7 @@ PyObject* PycapResources::pImageWidth(PyObject* self, PyObject* args)
     int index;
     if (!PyArg_ParseTuple(args, "i", &index)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "imageWidth: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "imageWidth: failed to parse arguments");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -393,7 +400,7 @@ PyObject* PycapResources::pImageWidth(PyObject* self, PyObject* args)
     // test for out of range
     if (index >= (int) sRes->images.size()) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't get image width: Index out of range.");
+        PyErr_SetString(PyExc_Exception, "Couldn't get image width: Index out of range.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -404,7 +411,7 @@ PyObject* PycapResources::pImageWidth(PyObject* self, PyObject* args)
     // test for already unloaded
     if (sRes->images[index] == NULL) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't get image width: Image not loaded.");
+        PyErr_SetString(PyExc_Exception, "Couldn't get image width: Image not loaded.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -426,7 +433,7 @@ PyObject* PycapResources::pImageHeight(PyObject* self, PyObject* args)
     int index;
     if (!PyArg_ParseTuple(args, "i", &index)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "imageHeight: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "imageHeight: failed to parse arguments");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -437,7 +444,7 @@ PyObject* PycapResources::pImageHeight(PyObject* self, PyObject* args)
     // test for out of range
     if (index >= (int) sRes->images.size()) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't get image height: Index out of range.");
+        PyErr_SetString(PyExc_Exception, "Couldn't get image height: Index out of range.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -448,7 +455,7 @@ PyObject* PycapResources::pImageHeight(PyObject* self, PyObject* args)
     // test for already unloaded
     if (sRes->images[index] == NULL) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't get image height: Image not loaded.");
+        PyErr_SetString(PyExc_Exception, "Couldn't get image height: Image not loaded.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -470,7 +477,7 @@ PyObject* PycapResources::pUnloadImage(PyObject* self, PyObject* args)
     int index;
     if (!PyArg_ParseTuple(args, "i", &index)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "unloadImage: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "unloadImage: failed to parse arguments");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -481,7 +488,7 @@ PyObject* PycapResources::pUnloadImage(PyObject* self, PyObject* args)
     // test for out of range
     if (index >= (int) sRes->images.size()) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't unload image: Index out of range.");
+        PyErr_SetString(PyExc_Exception, "Couldn't unload image: Index out of range.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -492,7 +499,7 @@ PyObject* PycapResources::pUnloadImage(PyObject* self, PyObject* args)
     // test for already unloaded
     if (sRes->images[index] == NULL) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't unload image: Image not loaded.");
+        PyErr_SetString(PyExc_Exception, "Couldn't unload image: Image not loaded.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -521,7 +528,7 @@ PyObject* PycapResources::pLoadFont(PyObject* self, PyObject* args)
     char* filename;
     if (!PyArg_ParseTuple(args, "s", &filename)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "loadFont: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "loadFont: failed to parse arguments");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -533,7 +540,7 @@ PyObject* PycapResources::pLoadFont(PyObject* self, PyObject* args)
     Font* newFont = sRes->loadFont(filename);
     if (!newFont) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Failed to load a font file.");
+        PyErr_SetString(PyExc_Exception, "Failed to load a font file.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -588,7 +595,7 @@ PyObject* PycapResources::pSysFont(PyObject* self, PyObject* args)
     Font* newFont = sRes->sysFont(faceName, pointSize, script, bold != 0, italics != 0, underline != 0);
     if (!newFont) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Failed to create a system font.");
+        PyErr_SetString(PyExc_Exception, "Failed to create a system font.");
 
         // exit, returning None/NULL
         return NULL;
@@ -618,7 +625,7 @@ PyObject* PycapResources::pSysFont(PyObject* self, PyObject* args)
     return Py_BuildValue("i", index);
 #else
     // throw an exception
-    PyErr_SetString(PyExc_StandardError, "sysfont: not supported!!");
+    PyErr_SetString(PyExc_Exception, "sysfont: not supported!!");
     PyErr_Print();
 
     // exit, returning None/NULL
@@ -638,7 +645,7 @@ PyObject* PycapResources::pStringWidth(PyObject* self, PyObject* args)
     int index;
     if (!PyArg_ParseTuple(args, "si", &string, &index)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "stringWidth: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "stringWidth: failed to parse arguments");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -649,7 +656,7 @@ PyObject* PycapResources::pStringWidth(PyObject* self, PyObject* args)
     // test for out of range
     if (index >= (int) sRes->fonts.size()) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't get string width: Font index out of range.");
+        PyErr_SetString(PyExc_Exception, "Couldn't get string width: Font index out of range.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -660,7 +667,7 @@ PyObject* PycapResources::pStringWidth(PyObject* self, PyObject* args)
     // test for already unloaded
     if (sRes->fonts[index] == NULL) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't get string width: Font not loaded.");
+        PyErr_SetString(PyExc_Exception, "Couldn't get string width: Font not loaded.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -682,7 +689,7 @@ PyObject* PycapResources::pFontAscent(PyObject* self, PyObject* args)
     int index;
     if (!PyArg_ParseTuple(args, "i", &index)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "fontAscent: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "fontAscent: failed to parse arguments");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -692,7 +699,7 @@ PyObject* PycapResources::pFontAscent(PyObject* self, PyObject* args)
     // test for out of range
     if (index >= (int) sRes->fonts.size()) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't get font height: Index out of range.");
+        PyErr_SetString(PyExc_Exception, "Couldn't get font height: Index out of range.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -704,7 +711,7 @@ PyObject* PycapResources::pFontAscent(PyObject* self, PyObject* args)
     // test for already unloaded
     if (sRes->fonts[index] == NULL) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't get font height: Font not loaded.");
+        PyErr_SetString(PyExc_Exception, "Couldn't get font height: Font not loaded.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -727,7 +734,7 @@ PyObject* PycapResources::pUnloadFont(PyObject* self, PyObject* args)
     int index;
     if (!PyArg_ParseTuple(args, "i", &index)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "unloadFont: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "unloadFont: failed to parse arguments");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -738,7 +745,7 @@ PyObject* PycapResources::pUnloadFont(PyObject* self, PyObject* args)
     // test for out of range
     if (index >= (int) sRes->fonts.size()) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't unload font: Index out of range.");
+        PyErr_SetString(PyExc_Exception, "Couldn't unload font: Index out of range.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -749,7 +756,7 @@ PyObject* PycapResources::pUnloadFont(PyObject* self, PyObject* args)
     // test for already unloaded
     if (sRes->fonts[index] == NULL) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't unload font: Font not loaded.");
+        PyErr_SetString(PyExc_Exception, "Couldn't unload font: Font not loaded.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -779,7 +786,7 @@ PyObject* PycapResources::pSetFontScale(PyObject* self, PyObject* args)
     float scale;
     if (!PyArg_ParseTuple(args, "if", &index, &scale)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "setFontScale: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "setFontScale: failed to parse arguments");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -790,7 +797,7 @@ PyObject* PycapResources::pSetFontScale(PyObject* self, PyObject* args)
     // test for out of range
     if (index >= (int) sRes->fonts.size()) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't set font point: Index out of range.");
+        PyErr_SetString(PyExc_Exception, "Couldn't set font point: Index out of range.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -802,7 +809,7 @@ PyObject* PycapResources::pSetFontScale(PyObject* self, PyObject* args)
     // test for already unloaded
     if (sRes->fonts[index] == NULL) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't set font point font: Font not loaded.");
+        PyErr_SetString(PyExc_Exception, "Couldn't set font point font: Font not loaded.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -815,7 +822,7 @@ PyObject* PycapResources::pSetFontScale(PyObject* self, PyObject* args)
     ImageFont* imageFont = dynamic_cast<ImageFont*> (sRes->fonts[index]);
     if (!imageFont) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't set font point font: Only supported by image fonts.");
+        PyErr_SetString(PyExc_Exception, "Couldn't set font point font: Only supported by image fonts.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -840,7 +847,7 @@ PyObject* PycapResources::pLoadSound(PyObject* self, PyObject* args)
     char* filename;
     if (!PyArg_ParseTuple(args, "s", &filename)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "loadSound: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "loadSound: failed to parse arguments");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -860,7 +867,7 @@ PyObject* PycapResources::pLoadSound(PyObject* self, PyObject* args)
     // attempt to load from the file
     if (!sRes->loadSound(slot, filename)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Failed to load a sound file.");
+        PyErr_SetString(PyExc_Exception, "Failed to load a sound file.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -894,7 +901,7 @@ PyObject* PycapResources::pUnloadSound(PyObject* self, PyObject* args)
     int index;
     if (!PyArg_ParseTuple(args, "i", &index)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "unloadSound: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "unloadSound: failed to parse arguments");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -905,7 +912,7 @@ PyObject* PycapResources::pUnloadSound(PyObject* self, PyObject* args)
     // test for out of range
     if (index >= (int) sRes->sounds.size()) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't unload sound: Index out of range.");
+        PyErr_SetString(PyExc_Exception, "Couldn't unload sound: Index out of range.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -916,7 +923,7 @@ PyObject* PycapResources::pUnloadSound(PyObject* self, PyObject* args)
     // test for already unloaded
     if (!sRes->sounds[index]) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't unload sound: Sound not loaded.");
+        PyErr_SetString(PyExc_Exception, "Couldn't unload sound: Sound not loaded.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -945,7 +952,7 @@ PyObject* PycapResources::pLoadTune(PyObject* self, PyObject* args)
     char* filename;
     if (!PyArg_ParseTuple(args, "s", &filename)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "loadTune: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "loadTune: failed to parse arguments");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -957,7 +964,7 @@ PyObject* PycapResources::pLoadTune(PyObject* self, PyObject* args)
 
     if (!PycapApp::sApp->mMusicInterface || !PycapApp::sApp->mMusicInterface->LoadMusic(index, filename)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Failed to load a music file.");
+        PyErr_SetString(PyExc_Exception, "Failed to load a music file.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -981,7 +988,7 @@ PyObject* PycapResources::pUnloadTune(PyObject* self, PyObject* args)
     int index;
     if (!PyArg_ParseTuple(args, "i", &index)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "unloadTune: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "unloadTune: failed to parse arguments");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -991,7 +998,7 @@ PyObject* PycapResources::pUnloadTune(PyObject* self, PyObject* args)
 
     if (index >= (int) sRes->tunes.size()) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Unable to unload music, invalid index!");
+        PyErr_SetString(PyExc_Exception, "Unable to unload music, invalid index!");
         // exit, returning None/NULL
         return Py_None;
     }
@@ -1002,7 +1009,7 @@ PyObject* PycapResources::pUnloadTune(PyObject* self, PyObject* args)
         *it = -1;
     } else {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Unable to unload music, music not found!");
+        PyErr_SetString(PyExc_Exception, "Unable to unload music, music not found!");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -1025,7 +1032,7 @@ PyObject* PycapResources::pGetPixel(PyObject* self, PyObject* args)
     int x, y;
     if (!PyArg_ParseTuple(args, "iii", &index, &x, &y)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "getPixel: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "getPixel: failed to parse arguments");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -1036,7 +1043,7 @@ PyObject* PycapResources::pGetPixel(PyObject* self, PyObject* args)
     // test for out of range
     if (index >= (int) sRes->images.size()) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't get pixel for image: Index out of range.");
+        PyErr_SetString(PyExc_Exception, "Couldn't get pixel for image: Index out of range.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -1048,7 +1055,7 @@ PyObject* PycapResources::pGetPixel(PyObject* self, PyObject* args)
     // test for already unloaded
     if (sRes->images[index] == NULL) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't get pixel for image: Image not loaded.");
+        PyErr_SetString(PyExc_Exception, "Couldn't get pixel for image: Image not loaded.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -1077,7 +1084,7 @@ PyObject* PycapResources::pGetPixel(PyObject* self, PyObject* args)
                 return Py_BuildValue("iiii", red, green, blue, alpha);
             } else {
                 // throw an exception
-                PyErr_SetString(PyExc_StandardError, "Couldn't get pixel: Coordinate is out of image bounds.");
+                PyErr_SetString(PyExc_Exception, "Couldn't get pixel: Coordinate is out of image bounds.");
                 PyErr_Print();
 
                 // exit, returning None/NULL
@@ -1087,7 +1094,7 @@ PyObject* PycapResources::pGetPixel(PyObject* self, PyObject* args)
             }
         } else {
             // throw an exception
-            PyErr_SetString(PyExc_StandardError, "Couldn't get pixel for image: GetBits() failed.");
+            PyErr_SetString(PyExc_Exception, "Couldn't get pixel for image: GetBits() failed.");
             PyErr_Print();
 
             // exit, returning None/NULL
@@ -1097,7 +1104,7 @@ PyObject* PycapResources::pGetPixel(PyObject* self, PyObject* args)
         }
     } else {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't get pixel for image: Image wouldn't cast to DDImage.");
+        PyErr_SetString(PyExc_Exception, "Couldn't get pixel for image: Image wouldn't cast to DDImage.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -1118,7 +1125,7 @@ PyObject* PycapResources::pSetPixel(PyObject* self, PyObject* args)
     int r, g, b, a;
     if (!PyArg_ParseTuple(args, "iiiiiii", &index, &x, &y, &r, &g, &b, &a)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "setPixel: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "setPixel: failed to parse arguments");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -1129,7 +1136,7 @@ PyObject* PycapResources::pSetPixel(PyObject* self, PyObject* args)
     // test for out of range
     if (index >= (int) sRes->images.size()) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't set pixel for image: Index out of range.");
+        PyErr_SetString(PyExc_Exception, "Couldn't set pixel for image: Index out of range.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -1140,7 +1147,7 @@ PyObject* PycapResources::pSetPixel(PyObject* self, PyObject* args)
     // test for already unloaded
     if (sRes->images[index] == NULL) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't set pixel for image: Image not loaded.");
+        PyErr_SetString(PyExc_Exception, "Couldn't set pixel for image: Image not loaded.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -1168,7 +1175,7 @@ PyObject* PycapResources::pSetPixel(PyObject* self, PyObject* args)
                 return Py_None;
             } else {
                 // throw an exception
-                PyErr_SetString(PyExc_StandardError, "Couldn't set pixel: Coordinate is out of image bounds.");
+                PyErr_SetString(PyExc_Exception, "Couldn't set pixel: Coordinate is out of image bounds.");
                 PyErr_Print();
 
                 // exit, returning None/NULL
@@ -1178,7 +1185,7 @@ PyObject* PycapResources::pSetPixel(PyObject* self, PyObject* args)
             }
         } else {
             // throw an exception
-            PyErr_SetString(PyExc_StandardError, "Couldn't set pixel for image: GetBits() failed.");
+            PyErr_SetString(PyExc_Exception, "Couldn't set pixel for image: GetBits() failed.");
             PyErr_Print();
 
             // exit, returning None/NULL
@@ -1188,7 +1195,7 @@ PyObject* PycapResources::pSetPixel(PyObject* self, PyObject* args)
         }
     } else {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't set pixel for image: Image wouldn't cast to DDImage.");
+        PyErr_SetString(PyExc_Exception, "Couldn't set pixel for image: Image wouldn't cast to DDImage.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -1208,7 +1215,7 @@ PyObject* PycapResources::pRefreshPixels(PyObject* self, PyObject* args)
     int index;
     if (!PyArg_ParseTuple(args, "i", &index)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "refreshPixels: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "refreshPixels: failed to parse arguments");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -1219,7 +1226,7 @@ PyObject* PycapResources::pRefreshPixels(PyObject* self, PyObject* args)
     // test for out of range
     if (index >= (int) sRes->images.size()) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't refresh pixels for image: Index out of range.");
+        PyErr_SetString(PyExc_Exception, "Couldn't refresh pixels for image: Index out of range.");
 
         PyErr_Print();
 
@@ -1231,7 +1238,7 @@ PyObject* PycapResources::pRefreshPixels(PyObject* self, PyObject* args)
     // test for already unloaded
     if (sRes->images[index] == NULL) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't refresh pixels for image: Image not loaded.");
+        PyErr_SetString(PyExc_Exception, "Couldn't refresh pixels for image: Image not loaded.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -1250,7 +1257,7 @@ PyObject* PycapResources::pRefreshPixels(PyObject* self, PyObject* args)
         return Py_None;
     } else {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't refresh pixels for image: Image wouldn't cast to DDImage.");
+        PyErr_SetString(PyExc_Exception, "Couldn't refresh pixels for image: Image wouldn't cast to DDImage.");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -1274,7 +1281,7 @@ PyObject* PycapResources::pMashPalette(PyObject* self, PyObject* args)
     int index;
     if (!PyArg_ParseTuple(args, "i", &index)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "mashPalette: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "mashPalette: failed to parse arguments");
         PyErr_Print();
 
         // exit, returning None/NULL
@@ -1285,7 +1292,7 @@ PyObject* PycapResources::pMashPalette(PyObject* self, PyObject* args)
     // test for already unloaded
     if (sRes->images[index] == NULL) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't mash palette for image: Image not loaded.");
+        PyErr_SetString(PyExc_Exception, "Couldn't mash palette for image: Image not loaded.");
 
         PyErr_Print();
 
@@ -1356,7 +1363,7 @@ PyObject* PycapResources::pMashImage(PyObject* self, PyObject* args)
     int index;
     if (!PyArg_ParseTuple(args, "i", &index)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "mashImage: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "mashImage: failed to parse arguments");
         PyErr_Print();
         // exit, returning None/NULL
         Py_INCREF(Py_None);
@@ -1366,7 +1373,7 @@ PyObject* PycapResources::pMashImage(PyObject* self, PyObject* args)
     // test for already unloaded
     if (sRes->images[index] == NULL) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "Couldn't mash image: Image not loaded.");
+        PyErr_SetString(PyExc_Exception, "Couldn't mash image: Image not loaded.");
         PyErr_Print();
         // exit, returning None/NULL
         Py_INCREF(Py_None);
@@ -1417,7 +1424,7 @@ PyObject* PycapResources::pImageGreyScale(PyObject* self, PyObject* args)
     int index;
     if (!PyArg_ParseTuple(args, "i", &index)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "imageGreyScale: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "imageGreyScale: failed to parse arguments");
         PyErr_Print();
         // exit, returning None/NULL
         Py_INCREF(Py_None);
@@ -1493,7 +1500,7 @@ PyObject* PycapResources::pImageGetLowBound(PyObject* self, PyObject* args)
     int index;
     if (!PyArg_ParseTuple(args, "i", &index)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "imageGetLowBound: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "imageGetLowBound: failed to parse arguments");
         PyErr_Print();
         // exit, returning None/NULL
         Py_INCREF(Py_None);
@@ -1545,7 +1552,7 @@ PyObject* PycapResources::pImageGetHighBound(PyObject* self, PyObject* args)
     int index;
     if (!PyArg_ParseTuple(args, "i", &index)) {
         // throw an exception
-        PyErr_SetString(PyExc_StandardError, "imageGetHighBound: failed to parse arguments");
+        PyErr_SetString(PyExc_Exception, "imageGetHighBound: failed to parse arguments");
         PyErr_Print();
         // exit, returning None/NULL
         Py_INCREF(Py_None);


### PR DESCRIPTION
This PR upgrades the Pycap part of TuxCap so that will run on Python 3. Recent versions of openSUSE (and probably other distros) no longer provide Python 2 binaries. Six months ago, [openSUSE Leap 15.4 dropped Python 2](https://code.opensuse.org/leap/features/issue/15).

These changes were needed to play GoOllie on Leap 15.5, although I had to patch GoOllie quite a bit to get it to stop giving me various Python errors related to integers, as Python 3 defaults to float division rather than integer division.

I also included a memory leak fix and a fix that allows the user to type lowercase letters in their name. Should these two commits be on a different branch?