### PR TITLE
Fix a memory leak in the SDL sound manager.

### DIFF
--- a/src/lib/SDLMixerSoundManager.cpp
+++ b/src/lib/SDLMixerSoundManager.cpp
@@ -198,6 +198,8 @@ void SDLMixerSoundManager::ReleaseSound(unsigned int theSfxID)
         for (int i = 0; i < MAX_CHANNELS; i++)
             if (mPlayingSounds[i] != NULL && mPlayingSounds[i]->mSample == mSourceSounds[theSfxID]) {
                 mPlayingSounds[i]->Release();
+                delete mPlayingSounds[i];
+                mPlayingSounds[i] = NULL;
                 break;
             }
         Mix_FreeChunk(mSourceSounds[theSfxID]);
@@ -284,15 +286,16 @@ void SDLMixerSoundManager::ReleaseChannels()
     for (int i = 0; i < MAX_CHANNELS; i++)
         if (mPlayingSounds[i]) {
             mPlayingSounds[i]->Release();
-            mPlayingSounds[i] = NULL;
         }
 }
 
 void SDLMixerSoundManager::ReleaseFreeChannels()
 {
     for (int i = 0; i < MAX_CHANNELS; i++)
-        if (mPlayingSounds[i] && mPlayingSounds[i]->IsReleased())
+        if (mPlayingSounds[i] && mPlayingSounds[i]->IsReleased()) {
+            delete mPlayingSounds[i];
             mPlayingSounds[i] = NULL;
+        }
 }
 
 void SDLMixerSoundManager::StopSound(int SfxID)


### PR DESCRIPTION
TuxCap has a memory leak in `SDLMixerSoundManager` class that leaks several 64-byte SoundInstance objects every time certain methods are called, and the leak ends up being several dozen kilobytes after playing a few levels of GoOllie. The leak is caused by NULLing out the only pointer to an object without deleting it first.

<details>

<summary> Leak Sanitizer memory leak report after playing a level of Go Ollie </summary>

```
cutsceneList English

=================================================================
==7625==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 56896 byte(s) in 889 object(s) allocated from:
    #0 0x7f17be2b2207 in operator new(unsigned long) (/usr/lib64/libasan.so.6+0xb2207)
    #1 0x7f17bbc53036 in Sexy::SDLMixerSoundManager::GetSoundInstance(unsigned int) /home/nathan/src/tuxcap/src/lib/SDLMixerSoundManager.cpp:249
    #2 0x7f17bbcf2a6e in Sexy::PycapApp::pPlaySound(_object*, _object*) /home/nathan/src/tuxcap/src/pycap/PycapApp.cpp:1098
    #3 0x7f17b9f2ba17  (/usr/lib64/libpython3.11.so.1.0+0x23ca17)

Direct leak of 13628 byte(s) in 6 object(s) allocated from:
    #0 0x7f17be2b0a9f in __interceptor_malloc (/usr/lib64/libasan.so.6+0xb0a9f)
    #1 0x7f17b9ed3839  (/usr/lib64/libpython3.11.so.1.0+0x1e4839)

Direct leak of 824 byte(s) in 1 object(s) allocated from:
    #0 0x7f17be2b0a9f in __interceptor_malloc (/usr/lib64/libasan.so.6+0xb0a9f)
    #1 0x7f17be1335f2  (/usr/lib64/libSDL2-2.0.so.0+0x675f2)

Direct leak of 96 byte(s) in 1 object(s) allocated from:
    #0 0x7f17be2b0c57 in __interceptor_calloc (/usr/lib64/libasan.so.6+0xb0c57)
    #1 0x7f17be133630  (/usr/lib64/libSDL2-2.0.so.0+0x67630)

Direct leak of 32 byte(s) in 2 object(s) allocated from:
    #0 0x7f17be2b0e18 in __interceptor_realloc (/usr/lib64/libasan.so.6+0xb0e18)
    #1 0x7f17bd5ad1fc  (/usr/lib64/libX11.so.6+0x591fc)

Indirect leak of 3087 byte(s) in 2 object(s) allocated from:
    #0 0x7f17be2b0a9f in __interceptor_malloc (/usr/lib64/libasan.so.6+0xb0a9f)
    #1 0x7f17be1335f2  (/usr/lib64/libSDL2-2.0.so.0+0x675f2)

Indirect leak of 672 byte(s) in 12 object(s) allocated from:
    #0 0x7f17be2b0c57 in __interceptor_calloc (/usr/lib64/libasan.so.6+0xb0c57)
    #1 0x7f17a65450a6  (<unknown module>)

Indirect leak of 320 byte(s) in 4 object(s) allocated from:
    #0 0x7f17be2b0c57 in __interceptor_calloc (/usr/lib64/libasan.so.6+0xb0c57)
    #1 0x7f17bd5ad1ce  (/usr/lib64/libX11.so.6+0x591ce)

Indirect leak of 128 byte(s) in 1 object(s) allocated from:
    #0 0x7f17be2b0c57 in __interceptor_calloc (/usr/lib64/libasan.so.6+0xb0c57)
    #1 0x7f17be133630  (/usr/lib64/libSDL2-2.0.so.0+0x67630)

Indirect leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x7f17be2b0c57 in __interceptor_calloc (/usr/lib64/libasan.so.6+0xb0c57)
    #1 0x7f17a6544f83  (<unknown module>)

Indirect leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x7f17be2b0c57 in __interceptor_calloc (/usr/lib64/libasan.so.6+0xb0c57)
    #1 0x7f17a6544f5f  (<unknown module>)

Indirect leak of 16 byte(s) in 2 object(s) allocated from:
    #0 0x7f17be2b0a9f in __interceptor_malloc (/usr/lib64/libasan.so.6+0xb0a9f)
    #1 0x7f17bd5adc09  (/usr/lib64/libX11.so.6+0x59c09)
    #2 0x676e0052473a30  (<unknown module>)

Indirect leak of 16 byte(s) in 2 object(s) allocated from:
    #0 0x7f17be2b0a9f in __interceptor_malloc (/usr/lib64/libasan.so.6+0xb0a9f)
    #1 0x7f17bd5adc09  (/usr/lib64/libX11.so.6+0x59c09)
    #2 0x676e004c473a30  (<unknown module>)

SUMMARY: AddressSanitizer: 75827 byte(s) leaked in 924 allocation(s).
```

</details>

Valgrind 3.20.0 also thinks that SDLMixerSoundManager::GetSoundInstance is leaking:
```
==11559== 1,408 bytes in 22 blocks are definitely lost in loss record 3,794 of 4,033
==11559==    at 0x4838EBF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11559==    by 0x5DC93DA: Sexy::SDLMixerSoundManager::GetSoundInstance(unsigned int) (SDLMixerSoundManager.cpp:249)
==11559==    by 0x5DE1469: Sexy::PycapApp::pPlaySound(_object*, _object*) (PycapApp.cpp:1098)
==11559==    by 0x60E1A17: ??? (in /usr/lib64/libpython3.11.so.1.0)
==11559==    by 0x60B5E87: _PyObject_MakeTpCall (in /usr/lib64/libpython3.11.so.1.0)
==11559==    by 0x609DD8B: _PyEval_EvalFrameDefault (in /usr/lib64/libpython3.11.so.1.0)
==11559==    by 0x5FBB55C: ??? (in /usr/lib64/libpython3.11.so.1.0)
==11559==    by 0x60A906A: _PyObject_Call (in /usr/lib64/libpython3.11.so.1.0)
==11559==    by 0x5DE3C8D: Sexy::PycapBoard::UpdateF(float) (PycapBoard.cpp:145)
==11559==    by 0x5D32A3E: Sexy::WidgetContainer::UpdateFAll(Sexy::ModalFlags*, float) (WidgetContainer.cpp:536)
==11559==    by 0x5D32AF0: Sexy::WidgetContainer::UpdateFAll(Sexy::ModalFlags*, float) (WidgetContainer.cpp:548)
==11559==    by 0x5D35588: Sexy::WidgetManager::UpdateFrameF(float) (WidgetManager.cpp:507)
```

**Valgrind** `(PYTHONMALLOC=malloc PYTHONPATH=../src valgrind --read-var-info=yes  --track-origins=yes --leak-check=full ./GoOllie)`