### PR TITLE
Avoid using deprecated FindPythonLibs.

### DIFF
--- a/src/CMakePycapDemo.txt
+++ b/src/CMakePycapDemo.txt
@@ -28,17 +28,17 @@ SET(MY_LINK_LIBS
 )
 
 
-INCLUDE(FindPythonLibs)
+Find_Package(Python3 COMPONENTS Development)
 
-IF (PYTHON_LIBRARIES)
+IF (Python3_LIBRARIES)
     MESSAGE("Python development libraries found, building TuxCap Python bindings and examples")
-    MESSAGE("Python libraries ${PYTHON_LIBRARIES} include path ${PYTHON_INCLUDE_PATH}")
-    SET(MY_LINK_LIBS    ${MY_LINK_LIBS} ${PYTHON_LIBRARIES})
+    MESSAGE("Python libraries ${Python3_LIBRARIES} include path ${Python3_INCLUDE_DIRS}")
+    SET(MY_LINK_LIBS    ${MY_LINK_LIBS} ${Python3_LIBRARIES})
     SET(MY_DIRS         ${MY_DIRS} pythondemo1 pythondemo2 pythondemo_template)
-    INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_PATH})
-ELSE (PYTHON_LIBRARIES)
+    INCLUDE_DIRECTORIES(${Python3_INCLUDE_DIRS})
+ELSE (Python3_LIBRARIES)
     MESSAGE("No Python development libraries found, skipping building of TuxCap Python bindings")
-ENDIF (PYTHON_LIBRARIES)
+ENDIF (Python3_LIBRARIES)
 
 SET(Libraries
     tuxcap
@@ -50,7 +50,7 @@ SET(Libraries
 INCLUDE_DIRECTORIES(${SDL_INCLUDE_DIR})
 INCLUDE_DIRECTORIES(${SDLIMAGE_INCLUDE_DIR})
 INCLUDE_DIRECTORIES(${OPENGL_INCLUDE_DIR})
-INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_PATH})
+INCLUDE_DIRECTORIES(${Python3_INCLUDE_DIRS})
 
 #the following block of code is an example of how to build an executable in
 #cmake.  Unmodified, it will add an executable called "MyExe" to the project.

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -52,17 +52,17 @@ SET(MY_LINK_LIBS
     ${PNG_LIBRARIES}
 )
 
-INCLUDE(FindPythonLibs)
+Find_Package(Python3 COMPONENTS Development)
 
-IF (PYTHON_LIBRARIES)
+IF (Python3_LIBRARIES)
     MESSAGE("Python development libraries found, building TuxCap Python bindings and examples")
-    MESSAGE("Python libraries ${PYTHON_LIBRARIES} include path ${PYTHON_INCLUDE_PATH}")
-    SET(MY_LINK_LIBS    ${MY_LINK_LIBS} ${PYTHON_LIBRARIES})
+    MESSAGE("Python libraries ${Python3_LIBRARIES} include path ${Python3_INCLUDE_DIRS}")
+    SET(MY_LINK_LIBS    ${MY_LINK_LIBS} ${Python3_LIBRARIES})
     SET(MY_DIRS         ${MY_DIRS} pythondemo1 pythondemo2 pythondemo_template)
-    INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_PATH})
-ELSE (PYTHON_LIBRARIES)
+    INCLUDE_DIRECTORIES(${Python3_INCLUDE_DIRS})
+ELSE (Python3_LIBRARIES)
     MESSAGE("No Python development libraries found, skipping building of TuxCap Python bindings")
-ENDIF (PYTHON_LIBRARIES)
+ENDIF (Python3_LIBRARIES)
 
 IF(SDL_FOUND)
     MESSAGE("libSDL found. ${SDL_INCLUDE_DIR} ${SDL_LIBRARY}")


### PR DESCRIPTION
This PR moves the CMake build system away from using the deprecated FindPythonLibs, and uses FindPython3 instead.