### PR TITLE
Resolve CMake policy warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ SET(CMAKE_FIND_FRAMEWORK FIRST)
 cmake_minimum_required(VERSION 2.6)
 if(COMMAND cmake_policy)
     cmake_policy(SET CMP0003 OLD)
+    cmake_policy(SET CMP0072 OLD) # Legacy OpenGL library instead of GLVND
 endif(COMMAND cmake_policy)
 
 # To build with debug info

--- a/src/CMakeDemo.txt
+++ b/src/CMakeDemo.txt
@@ -50,5 +50,6 @@ ADD_EXECUTABLE(${CurrentExe}
 ADD_DEPENDENCIES(${CurrentExe}
     bin
 )
+set_target_properties(${CurrentExe} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
 TARGET_LINK_LIBRARIES(${CurrentExe} ${Libraries})

--- a/src/CMakePycapDemo.txt
+++ b/src/CMakePycapDemo.txt
@@ -66,3 +66,4 @@ ADD_DEPENDENCIES(${CurrentExe}
 )
 
 TARGET_LINK_LIBRARIES(${CurrentExe} ${Libraries})
+set_target_properties(${CurrentExe} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")

--- a/src/demo1/CMakeLists.txt
+++ b/src/demo1/CMakeLists.txt
@@ -1,6 +1,6 @@
 SET(MY_SOURCES main.cpp Board.cpp GameApp.cpp)
 # The "../../bin" puts in in BUILD/bin and that will help the program
 # to find the resource directory in BUILD/bin/../Resources
-SET(CurrentExe "../../bin/demo_1")
+SET(CurrentExe "demo_1")
 
 INCLUDE(../CMakeDemo.txt)

--- a/src/demo2/CMakeLists.txt
+++ b/src/demo2/CMakeLists.txt
@@ -1,6 +1,6 @@
 SET(MY_SOURCES main.cpp Board.cpp GameApp.cpp)
 # The "../../bin" puts in in BUILD/bin and that will help the program
 # to find the resource directory in BUILD/bin/../Resources
-SET(CurrentExe "../../bin/demo_2")
+SET(CurrentExe "demo_2")
 
 INCLUDE(../CMakeDemo.txt)

--- a/src/demo3/CMakeLists.txt
+++ b/src/demo3/CMakeLists.txt
@@ -1,6 +1,6 @@
 SET(MY_SOURCES main.cpp Board.cpp GameApp.cpp)
 # The "../../bin" puts in in BUILD/bin and that will help the program
 # to find the resource directory in BUILD/bin/../Resources
-SET(CurrentExe "../../bin/demo_3")
+SET(CurrentExe "demo_3")
 
 INCLUDE(../CMakeDemo.txt)

--- a/src/demo4/CMakeLists.txt
+++ b/src/demo4/CMakeLists.txt
@@ -1,6 +1,6 @@
 SET(MY_SOURCES main.cpp TitleScreen.cpp Board.cpp GameApp.cpp Res.cpp)
 # The "../../bin" puts in in BUILD/bin and that will help the program
 # to find the resource directory in BUILD/bin/../Resources
-SET(CurrentExe "../../bin/demo_4")
+SET(CurrentExe "demo_4")
 
 INCLUDE(../CMakeDemo.txt)

--- a/src/demo5/CMakeLists.txt
+++ b/src/demo5/CMakeLists.txt
@@ -1,6 +1,6 @@
 SET(MY_SOURCES main.cpp TitleScreen.cpp DemoDialog.cpp Board.cpp GameApp.cpp Res.cpp)
 # The "../../bin" puts in in BUILD/bin and that will help the program
 # to find the resource directory in BUILD/bin/../Resources
-SET(CurrentExe "../../bin/demo_5")
+SET(CurrentExe "demo_5")
 
 INCLUDE(../CMakeDemo.txt)

--- a/src/hungarr/CMakeLists.txt
+++ b/src/hungarr/CMakeLists.txt
@@ -2,6 +2,6 @@ SET(MY_SOURCES  main.cpp TitleScreen.cpp OptionsDialog.cpp GameOverEffect.cpp Le
     Board.cpp GameApp.h GameApp.cpp Res.cpp)
 # The "../../bin" puts in in BUILD/bin and that will help the program
 # to find the resource directory in BUILD/bin/../Resources
-SET(CurrentExe "../../bin/Hungarr")
+SET(CurrentExe "Hungarr")
 
 INCLUDE(../CMakeDemo.txt)

--- a/src/particledemo/CMakeLists.txt
+++ b/src/particledemo/CMakeLists.txt
@@ -1,6 +1,6 @@
 SET(MY_SOURCES main.cpp Board.cpp GameApp.cpp)
 # The "../../bin" puts in in BUILD/bin and that will help the program
 # to find the resource directory in BUILD/bin/../Resources
-SET(CurrentExe "../../bin/particle_demo")
+SET(CurrentExe "particle_demo")
 
 INCLUDE(../CMakeDemo.txt)

--- a/src/physicsdemo/CMakeLists.txt
+++ b/src/physicsdemo/CMakeLists.txt
@@ -1,6 +1,6 @@
 SET(MY_SOURCES main.cpp Board.cpp GameApp.cpp)
 # The "../../bin" puts in in BUILD/bin and that will help the program
 # to find the resource directory in BUILD/bin/../Resources
-SET(CurrentExe "../../bin/Physicsdemo")
+SET(CurrentExe "Physicsdemo")
 
 INCLUDE(../CMakeDemo.txt)

--- a/src/physicsdemo2/CMakeLists.txt
+++ b/src/physicsdemo2/CMakeLists.txt
@@ -1,6 +1,6 @@
 SET(MY_SOURCES main.cpp Board.cpp GameApp.cpp)
 # The "../../bin" puts in in BUILD/bin and that will help the program
 # to find the resource directory in BUILD/bin/../Resources
-SET(CurrentExe "../../bin/Physicsdemo2")
+SET(CurrentExe "Physicsdemo2")
 
 INCLUDE(../CMakeDemo.txt)

--- a/src/physicsdemo3/CMakeLists.txt
+++ b/src/physicsdemo3/CMakeLists.txt
@@ -1,6 +1,6 @@
 SET(MY_SOURCES main.cpp Board.cpp GameApp.cpp)
 # The "../../bin" puts in in BUILD/bin and that will help the program
 # to find the resource directory in BUILD/bin/../Resources
-SET(CurrentExe "../../bin/Physicsdemo3")
+SET(CurrentExe "Physicsdemo3")
 
 INCLUDE(../CMakeDemo.txt)

--- a/src/physicsdemo4/CMakeLists.txt
+++ b/src/physicsdemo4/CMakeLists.txt
@@ -1,6 +1,6 @@
 SET(MY_SOURCES main.cpp Board.cpp GameApp.cpp)
 # The "../../bin" puts in in BUILD/bin and that will help the program
 # to find the resource directory in BUILD/bin/../Resources
-SET(CurrentExe "../../bin/Physicsdemo4")
+SET(CurrentExe "Physicsdemo4")
 
 INCLUDE(../CMakeDemo.txt)

--- a/src/physicsdemo5/CMakeLists.txt
+++ b/src/physicsdemo5/CMakeLists.txt
@@ -1,6 +1,6 @@
 SET(MY_SOURCES main.cpp Board.cpp GameApp.cpp)
 # The "../../bin" puts in in BUILD/bin and that will help the program
 # to find the resource directory in BUILD/bin/../Resources
-SET(CurrentExe "../../bin/Physicsdemo5")
+SET(CurrentExe "Physicsdemo5")
 
 INCLUDE(../CMakeDemo.txt)

--- a/src/physicsdemo6/CMakeLists.txt
+++ b/src/physicsdemo6/CMakeLists.txt
@@ -1,6 +1,6 @@
 SET(MY_SOURCES main.cpp Board.cpp GameApp.cpp)
 # The "../../bin" puts in in BUILD/bin and that will help the program
 # to find the resource directory in BUILD/bin/../Resources
-SET(CurrentExe "../../bin/Physicsdemo6")
+SET(CurrentExe "Physicsdemo6")
 
 INCLUDE(../CMakeDemo.txt)

--- a/src/physicsdemo7/CMakeLists.txt
+++ b/src/physicsdemo7/CMakeLists.txt
@@ -1,1 +1,2 @@
 SET(MY_SOURCES main.cpp Board.cpp GameApp.cpp)
+SET(CurrentExe "physicsdemo7")

--- a/src/pythondemo1/CMakeLists.txt
+++ b/src/pythondemo1/CMakeLists.txt
@@ -1,7 +1,7 @@
 SET(MY_SOURCES  main.cpp)
 # The "../../bin" puts in in BUILD/bin and that will help the program
 # to find the resource directory in BUILD/bin/../Resources
-SET(CurrentExe "../../bin/pythondemo1")
+SET(CurrentExe "pythondemo1")
 
 INCLUDE(../CMakePycapDemo.txt)
 


### PR DESCRIPTION
Fixes issue #7 involving policy CMP0037 warnings by setting the output directory to bin and changing all the demo's target names to base names instead of relative paths.

Second commit fixes a CMP0072 warning about LEGACY vs GLVND OpenGL libraries.