### PR TITLE
Fix window turning black when I switch screen modes

### DIFF
--- a/src/lib/D3DInterface.cpp
+++ b/src/lib/D3DInterface.cpp
@@ -223,6 +223,7 @@ bool D3DInterface::InitD3D()
     UpdateViewport();
 
     glMatrixMode(GL_TEXTURE);
+    glLoadIdentity();
     glScalef(1.0f / TEXTURESCALING, 1.0f / TEXTURESCALING, 1.0f / TEXTURESCALING);
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();

--- a/src/lib/DDImage.cpp
+++ b/src/lib/DDImage.cpp
@@ -613,7 +613,7 @@ void DDImage::FillRect(const Rect& theRect, const Color& theColor, int theDrawMo
     }
 
     // It makes no sense that we get here with a DDImage and no 3D!
-    assert(0);
+    //assert(0);
 
     CommitBits();
     if ((mDrawToBits) || (mHasAlpha) || ((mHasTrans) && (!mFirstPixelTrans)) || (mDDInterface->mIs3D)) {

--- a/src/lib/DDInterface.cpp
+++ b/src/lib/DDInterface.cpp
@@ -584,7 +584,7 @@ bool DDInterface::Redraw(Rect* theClipRect)
         SDL_GL_SwapWindow(gSexyAppBase->GetMainWindow());
     else {
 #if SDL_VERSION_ATLEAST(2,0,0)
-	// ????
+        SDL_UpdateWindowSurface(gSexyAppBase->GetMainWindow());
 #else
         SDL_Flip(mScreenImage->mSurface);
 #endif

--- a/src/lib/SexyAppBase.cpp
+++ b/src/lib/SexyAppBase.cpp
@@ -2804,8 +2804,8 @@ void SexyAppBase::MakeWindow_SoftwareRendered(bool isWindowed, int bpp)
     // For now just let's always make a "windowed" window (not fullscreen)
     mVideoModeWidth = mWidth;
     mVideoModeHeight = mHeight;
-    SDL_Window * win = SDL_CreateWindow(NULL, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, mWidth, mHeight, SDL_WINDOW_SHOWN);
-    mScreenSurface = SDL_GetWindowSurface(win);
+    mMainWindow = SDL_CreateWindow(NULL, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, mWidth, mHeight, SDL_WINDOW_SHOWN);
+    mScreenSurface = SDL_GetWindowSurface(mMainWindow);
 #else
     // ???? Is this always "windowed"?
     if (mScreenSurface != NULL) {

--- a/src/lib/WidgetManager.cpp
+++ b/src/lib/WidgetManager.cpp
@@ -429,7 +429,9 @@ bool WidgetManager::DrawScreen()
     mMinDeferredOverlayPriority = 0x7FFFFFFF;
     mDeferredOverlayWidgets.resize(0);
 
-    HWGraphics aScrG(gSexyAppBase->mDDInterface, gSexyAppBase->mWidth, gSexyAppBase->mHeight);
+    HWGraphics aScrGHW(gSexyAppBase->mDDInterface, gSexyAppBase->mWidth, gSexyAppBase->mHeight);
+    Graphics aScrGSW(mImage);
+    Graphics& aScrG = gSexyAppBase->Is3DAccelerated() ? aScrGHW : aScrGSW;
 
     DDImage* aDDImage = dynamic_cast<DDImage*>(mImage);
     bool surfaceLocked = false;


### PR DESCRIPTION
This fixes the "Go Ollie!" window turning black when switching between fullscreen and windowed with OpenGL hardware acceleration enabled. Took me about three weeks to debug this. I tried reusing the window before, and also tried putting a `glLoadIdentity` right after changing to the texture matrix, but didn't think to try both the changes together until today.

I haven't yet fixed the bug where turning hardware acceleration off in GoOllie causes the game to open a blank window while keeping the original window open. I've narrowed it down to the WidgetManager class always using a HWGraphics when it should perhaps be using the superclass Graphics instead when `gSexyAppBase->Is3DAccelerated()` is false.